### PR TITLE
feat : 시큐리티 + JWT+ OAuth2 카카오 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,15 @@ dependencies {
 	// 테스트용 H2
 	testImplementation 'com.h2database:h2'
 
+	// OAuth2
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
+	// jwt
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+
 }
 
 tasks.named('test') {

--- a/src/main/java/avengers/lion/auth/domain/KakaoMemberDetails.java
+++ b/src/main/java/avengers/lion/auth/domain/KakaoMemberDetails.java
@@ -1,0 +1,36 @@
+package avengers.lion.auth.domain;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+/*
+인증 객체인 Authentication 객체안에 사용자 정보를 담기 위한 클래스
+OAuth2User 인터페이스의 구현체로 작성해야 Authentication 객체 안에 담을 수 있음
+ */
+@RequiredArgsConstructor
+public class KakaoMemberDetails implements OAuth2User {
+
+    private final String email;
+    private final List<? extends GrantedAuthority> authorities;
+    private final Map<String, Object> attributes;
+
+    @Override
+    public String getName() {
+        return email;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return authorities;
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+}

--- a/src/main/java/avengers/lion/auth/domain/KakaoUserInfo.java
+++ b/src/main/java/avengers/lion/auth/domain/KakaoUserInfo.java
@@ -1,0 +1,67 @@
+package avengers.lion.auth.domain;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.util.Map;
+
+public class KakaoUserInfo {
+
+    public static final String KAKAO_ACCOUNT = "kakao_account";
+    public static final String PROFILE = "profile";
+    public static final String PROPERTIES = "properties";
+    public static final String EMAIL = "email";
+    public static final String NICKNAME = "nickname";
+    public static final String PROFILE_IMAGE = "profile_image_url";
+
+    // 카카오 프로바이더에서 받은 원본 사용자 정보 맵
+    private Map<String, Object> attributes;
+
+    public KakaoUserInfo(Map<String, Object> attributes){
+        this.attributes=attributes;
+    }
+
+    // 이메일 추출 메소드
+    public String getEmail() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        TypeReference<Map<String, Object>> typeReferencer = new TypeReference<Map<String, Object>>() {};
+
+        Object kakaoAccount = attributes.get(KAKAO_ACCOUNT);
+        if (kakaoAccount == null) return null;
+        
+        Map<String, Object> account = objectMapper.convertValue(kakaoAccount, typeReferencer);
+        return (String) account.get(EMAIL);
+    }
+
+    // 닉네임 추출 메소드
+    public String getNickname() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        TypeReference<Map<String, Object>> typeReferencer = new TypeReference<Map<String, Object>>() {};
+
+        Object kakaoAccount = attributes.get(KAKAO_ACCOUNT);
+        if (kakaoAccount == null) return null;
+        
+        Map<String, Object> account = objectMapper.convertValue(kakaoAccount, typeReferencer);
+        Object profile = account.get(PROFILE);
+        if (profile == null) return null;
+        
+        Map<String, Object> profileMap = objectMapper.convertValue(profile, typeReferencer);
+        return (String) profileMap.get(NICKNAME);
+    }
+
+    // 프로필 이미지 추출 메소드
+    public String getProfileImageUrl() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        TypeReference<Map<String, Object>> typeReferencer = new TypeReference<Map<String, Object>>() {};
+
+        Object kakaoAccount = attributes.get(KAKAO_ACCOUNT);
+        if (kakaoAccount == null) return null;
+        
+        Map<String, Object> account = objectMapper.convertValue(kakaoAccount, typeReferencer);
+        Object profile = account.get(PROFILE);
+        if (profile == null) return null;
+        
+        Map<String, Object> profileMap = objectMapper.convertValue(profile, typeReferencer);
+        return (String) profileMap.get(PROFILE_IMAGE);
+    }
+}

--- a/src/main/java/avengers/lion/auth/domain/KakaoUserInfo.java
+++ b/src/main/java/avengers/lion/auth/domain/KakaoUserInfo.java
@@ -14,54 +14,63 @@ public class KakaoUserInfo {
     public static final String NICKNAME = "nickname";
     public static final String PROFILE_IMAGE = "profile_image_url";
 
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final TypeReference<Map<String, Object>> TYPE_REFERENCE =
+            new TypeReference<Map<String, Object>>() {};
+    
     // 카카오 프로바이더에서 받은 원본 사용자 정보 맵
     private Map<String, Object> attributes;
 
     public KakaoUserInfo(Map<String, Object> attributes){
         this.attributes=attributes;
     }
+    private Map<String, Object> getKakaoAccount() {
+        Object kakaoAccount = attributes.get(KAKAO_ACCOUNT);
+        if (kakaoAccount == null) return null;
+
+        try{
+            return OBJECT_MAPPER.convertValue(kakaoAccount, TYPE_REFERENCE);
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+
+    private Map<String, Object> getProfile(Map<String, Object> kakaoAccount) {
+        if(kakaoAccount==null) return null;
+
+        Object profile = kakaoAccount.get(PROFILE);
+        if (profile == null) return null;
+
+        try{
+            return OBJECT_MAPPER.convertValue(profile, TYPE_REFERENCE);
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
 
     // 이메일 추출 메소드
     public String getEmail() {
-        ObjectMapper objectMapper = new ObjectMapper();
-        TypeReference<Map<String, Object>> typeReferencer = new TypeReference<Map<String, Object>>() {};
-
-        Object kakaoAccount = attributes.get(KAKAO_ACCOUNT);
-        if (kakaoAccount == null) return null;
         
-        Map<String, Object> account = objectMapper.convertValue(kakaoAccount, typeReferencer);
-        return (String) account.get(EMAIL);
+      Map<String, Object> kakaoAccount = getKakaoAccount();
+      if(kakaoAccount==null) return null;
+      return (String) kakaoAccount.get(EMAIL);
     }
 
     // 닉네임 추출 메소드
     public String getNickname() {
-        ObjectMapper objectMapper = new ObjectMapper();
-        TypeReference<Map<String, Object>> typeReferencer = new TypeReference<Map<String, Object>>() {};
-
-        Object kakaoAccount = attributes.get(KAKAO_ACCOUNT);
-        if (kakaoAccount == null) return null;
-        
-        Map<String, Object> account = objectMapper.convertValue(kakaoAccount, typeReferencer);
-        Object profile = account.get(PROFILE);
-        if (profile == null) return null;
-        
-        Map<String, Object> profileMap = objectMapper.convertValue(profile, typeReferencer);
-        return (String) profileMap.get(NICKNAME);
+       
+      Map<String, Object> kakaoAccount = getKakaoAccount();
+      Map<String, Object> profile = getProfile(kakaoAccount);
+      if(profile==null) return null;
+      return (String) profile.get(NICKNAME);
     }
 
     // 프로필 이미지 추출 메소드
     public String getProfileImageUrl() {
-        ObjectMapper objectMapper = new ObjectMapper();
-        TypeReference<Map<String, Object>> typeReferencer = new TypeReference<Map<String, Object>>() {};
-
-        Object kakaoAccount = attributes.get(KAKAO_ACCOUNT);
-        if (kakaoAccount == null) return null;
-        
-        Map<String, Object> account = objectMapper.convertValue(kakaoAccount, typeReferencer);
-        Object profile = account.get(PROFILE);
-        if (profile == null) return null;
-        
-        Map<String, Object> profileMap = objectMapper.convertValue(profile, typeReferencer);
-        return (String) profileMap.get(PROFILE_IMAGE);
+      
+        Map<String, Object> kakaoAccount = getKakaoAccount();
+        Map<String, Object> profile = getProfile(kakaoAccount);
+        if(profile==null) return null;
+        return (String) profile.get(PROFILE_IMAGE);
     }
 }

--- a/src/main/java/avengers/lion/auth/repository/MemberRepository.java
+++ b/src/main/java/avengers/lion/auth/repository/MemberRepository.java
@@ -1,0 +1,13 @@
+package avengers.lion.auth.repository;
+
+import avengers.lion.member.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    Optional<Member> findByEmail(String email);
+}

--- a/src/main/java/avengers/lion/auth/service/KakaoMemberDetailsService.java
+++ b/src/main/java/avengers/lion/auth/service/KakaoMemberDetailsService.java
@@ -47,6 +47,5 @@ public class KakaoMemberDetailsService extends DefaultOAuth2UserService {
         return new KakaoMemberDetails(String.valueOf(member.getEmail()),
                 Collections.singletonList(authority),
                 oAuth2User.getAttributes());
-
     }
 }

--- a/src/main/java/avengers/lion/auth/service/KakaoMemberDetailsService.java
+++ b/src/main/java/avengers/lion/auth/service/KakaoMemberDetailsService.java
@@ -1,0 +1,52 @@
+package avengers.lion.auth.service;
+
+
+import avengers.lion.auth.domain.KakaoMemberDetails;
+import avengers.lion.auth.domain.KakaoUserInfo;
+import avengers.lion.auth.repository.MemberRepository;
+import avengers.lion.member.Member;
+import avengers.lion.member.MemberRole;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+
+@Service
+@RequiredArgsConstructor
+/*
+OAuth2 사용자 정보 처리
+ */
+public class KakaoMemberDetailsService extends DefaultOAuth2UserService {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    @Transactional
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+        // request 에서 사용자 정보가 담긴 객체를 가져옴
+        KakaoUserInfo kakaoUserInfo = new KakaoUserInfo(oAuth2User.getAttributes());
+
+        Member member = memberRepository.findByEmail(kakaoUserInfo.getEmail())
+                .orElseGet(()->
+                        memberRepository.save(
+                                Member.builder()
+                                        .email(kakaoUserInfo.getEmail())
+                                        .nickname(kakaoUserInfo.getNickname())
+                                        .profileImageUrl(kakaoUserInfo.getProfileImageUrl())
+                                        .role(MemberRole.ROLE_USER)
+                                        .build()
+                        ));
+        SimpleGrantedAuthority authority = new SimpleGrantedAuthority(member.getRole().name());
+        return new KakaoMemberDetails(String.valueOf(member.getEmail()),
+                Collections.singletonList(authority),
+                oAuth2User.getAttributes());
+
+    }
+}

--- a/src/main/java/avengers/lion/global/OAuth2SuccessHandler.java
+++ b/src/main/java/avengers/lion/global/OAuth2SuccessHandler.java
@@ -1,0 +1,74 @@
+package avengers.lion.global;
+
+import avengers.lion.auth.domain.KakaoUserInfo;
+import avengers.lion.auth.repository.MemberRepository;
+import avengers.lion.global.exception.BusinessException;
+import avengers.lion.global.exception.ExceptionType;
+import avengers.lion.global.jwt.TokenDto;
+import avengers.lion.global.jwt.TokenProvider;
+import avengers.lion.global.response.SuccessResponseBody;
+import avengers.lion.member.Member;
+import avengers.lion.member.MemberRole;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+
+/*
+카카오 로그인 성공 후 실행되는 커스텀 핸들러
+우리 서비스 전용 JWT를 발급하고, 클라이언트를 accessToken, refreshToken을 담은 URL로 리다이렉트 하는 역할
+SimpleUrl~~ : 스프링 시큐리티의 기본 성공 핸들러
+ */
+public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    private final TokenProvider tokenProvider;
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+                                        Authentication authentication) throws IOException, ServletException{
+        // 카카오에서 내려준 사용자 정보를 꺼냄
+        OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
+        // 파싱하기 위한 래퍼 클래스
+        KakaoUserInfo kakaoUserInfo = new KakaoUserInfo(oAuth2User.getAttributes());
+
+        // DB에 이메일로 가입된 유저가 있는지 확인, 없으면 신규 회원 생성
+        Member member = memberRepository.findByEmail(kakaoUserInfo.getEmail())
+                .orElseGet(()->
+                        memberRepository.save(
+                                Member.builder()
+                                        .email(kakaoUserInfo.getEmail())
+                                        .nickname(kakaoUserInfo.getNickname())
+                                        .profileImageUrl(kakaoUserInfo.getProfileImageUrl())
+                                        .role(MemberRole.ROLE_USER)
+                                        .build()
+                        ));
+
+        // 사용자 식별 정보를 이용해 토큰 발급
+        TokenDto tokenDto = tokenProvider.createToken(member.getEmail(), member.getRole().name());
+
+        // JSON 응답으로 토큰 반환
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        response.setStatus(HttpServletResponse.SC_OK);
+
+        SuccessResponseBody<TokenDto> successResponse = new SuccessResponseBody<>(tokenDto);
+        
+        ObjectMapper objectMapper = new ObjectMapper();
+        String jsonResponse = objectMapper.writeValueAsString(successResponse);
+        response.getWriter().write(jsonResponse);
+    }
+}

--- a/src/main/java/avengers/lion/global/config/CorsConfig.java
+++ b/src/main/java/avengers/lion/global/config/CorsConfig.java
@@ -1,0 +1,18 @@
+package avengers.lion.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(final CorsRegistry registry){
+        registry.addMapping("/**")
+                .allowedOrigins("http://localhost:5173")
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH")
+                .allowCredentials(true);
+        WebMvcConfigurer.super.addCorsMappings(registry);
+    }
+}

--- a/src/main/java/avengers/lion/global/config/security/SecurityConfig.java
+++ b/src/main/java/avengers/lion/global/config/security/SecurityConfig.java
@@ -6,6 +6,7 @@ import avengers.lion.global.jwt.JwtAccessDeniedHandler;
 import avengers.lion.global.jwt.JwtAuthenticationFailEntryPoint;
 import avengers.lion.global.jwt.JwtFilter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -23,6 +24,9 @@ public class SecurityConfig {
     private final JwtFilter jwtFilter;
     private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
     private final JwtAuthenticationFailEntryPoint jwtAuthenticationFailEntryPoint;
+
+    @Value("${spring.security.oauth2.client.registration.kakao.redirect-uri}")
+    private String REDIRECT_URL;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http, OAuth2SuccessHandler oAuth2SuccessHandler) throws Exception {
@@ -45,7 +49,7 @@ public class SecurityConfig {
                         .authorizationEndpoint(authz -> authz
                                 .baseUri("/oauth2/authorize"))
                         .redirectionEndpoint(redir -> redir
-                                .baseUri("/oauth2/callback/*"))
+                                .baseUri(REDIRECT_URL))
                         .userInfoEndpoint(ui -> ui
                                 .userService(KakaoMemberDetailsService))
                         // 카카오 로그인에 성공하면, 실행

--- a/src/main/java/avengers/lion/global/config/security/SecurityConfig.java
+++ b/src/main/java/avengers/lion/global/config/security/SecurityConfig.java
@@ -1,0 +1,67 @@
+package avengers.lion.global.config.security;
+
+import avengers.lion.auth.service.KakaoMemberDetailsService;
+import avengers.lion.global.OAuth2SuccessHandler;
+import avengers.lion.global.jwt.JwtAccessDeniedHandler;
+import avengers.lion.global.jwt.JwtAuthenticationFailEntryPoint;
+import avengers.lion.global.jwt.JwtFilter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final KakaoMemberDetailsService KakaoMemberDetailsService;
+    private final JwtFilter jwtFilter;
+    private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+    private final JwtAuthenticationFailEntryPoint jwtAuthenticationFailEntryPoint;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http, OAuth2SuccessHandler oAuth2SuccessHandler) throws Exception {
+        http
+                // CSRF 비활성화
+                .csrf(csrf -> csrf.disable())
+
+                // 세션 사용 x
+                .sessionManagement(sm -> sm
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                )
+                // URL 접근 권한 설정
+                .authorizeHttpRequests(auth -> auth
+                        // 로그인, 콜백, 퍼블릭 API 허용
+                        .requestMatchers("/", "/oauth2/**", "/login", "/error").permitAll()
+                        .anyRequest().authenticated()
+                )
+                // OAuth2 로그인 설정
+                .oauth2Login(oauth2 -> oauth2
+                        .authorizationEndpoint(authz -> authz
+                                .baseUri("/oauth2/authorize"))
+                        .redirectionEndpoint(redir -> redir
+                                .baseUri("/oauth2/callback/*"))
+                        .userInfoEndpoint(ui -> ui
+                                .userService(KakaoMemberDetailsService))
+                        // 카카오 로그인에 성공하면, 실행
+                        .successHandler(oAuth2SuccessHandler)
+                )
+                .logout(logout -> logout
+                        .logoutSuccessUrl("/")
+                        .invalidateHttpSession(true)
+                        .deleteCookies("JSESSIONID")
+                ).addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
+                // JWT 예외 처리 핸들러 설정
+                .exceptionHandling(ex -> ex
+                        .accessDeniedHandler(jwtAccessDeniedHandler)
+                        .authenticationEntryPoint(jwtAuthenticationFailEntryPoint)
+                );
+
+        return http.build();
+    }
+}

--- a/src/main/java/avengers/lion/global/config/swagger/SwaggerConfig.java
+++ b/src/main/java/avengers/lion/global/config/swagger/SwaggerConfig.java
@@ -17,10 +17,10 @@ import org.springframework.web.method.HandlerMethod;
 @Configuration
 @Profile("!test && !prod")
 public class SwaggerConfig {
-    @Value("${job-foreigner.swagger.server-url}")
+    @Value("${swagger.server.url}")
     private String serverUrl;
 
-    @Value("${job-foreigner.swagger.description}")
+    @Value("${swagger.server.description}")
     private String serverDescription;
 
     @Bean
@@ -52,7 +52,7 @@ public class SwaggerConfig {
     private Info apiInfo() {
         return new Info()
                 .title("JobForeigner API 명세서")
-                .description("<p>이 문서는 JobForeigner 백엔드 API의 사용 방법과 예시를 제공합니다.</p>" +
+                .description("<p>이 문서는 LetsGGu 백엔드 API의 사용 방법과 예시를 제공합니다.</p>" +
                         "<p>API 사용 중 문제가 발생하거나 문의가 필요한 경우, 담당자에게 문의해 주세요.</p>" +
                         "<p>입력 유효성 오류는 명시돼 있지 않으며 <code>4XX</code> 상태 코드를 반환합니다." +
                         "<code>5XX</code> 상태 코드의 경우 정의되지 않은 서버 오류이므로 담당자에게 문의해 주세요.</p>")

--- a/src/main/java/avengers/lion/global/exception/ExceptionType.java
+++ b/src/main/java/avengers/lion/global/exception/ExceptionType.java
@@ -18,50 +18,6 @@ public enum ExceptionType {
 
     // Member
     MEMBER_NOT_FOUND(NOT_FOUND, "U001", "사용자를 찾을 수 없습니다."),
-    MEMBER_INFO_INVALID(UNAUTHORIZED, "U002", "아이디 또는 비밀번호가 일치하지 않습니다."),
-    USERNAME_ALREADY_EXISTS(CONFLICT, "U003", "이미 등록되어 있거나 사용할 수 없는 아이디입니다."),
-    EMAIL_ALREADY_EXISTS(CONFLICT, "U004", "이미 등록되어 있거나 사용할 수 없는 이메일 주소입니다."),
-    COMPANY_ALREADY_EXISTS(CONFLICT, "U005", "이미 담당자 정보가 등록된 회사입니다."),
-    EMAIL_VERIFICATION_REQUIRED(UNAUTHORIZED, "U006", "이메일 주소 인증이 필요합니다."),
-    EMAIL_ALREADY_VERIFIED(CONFLICT, "U007", "이미 인증된 이메일 주소입니다."),
-    AUTH_CODE_INVALID(CONFLICT, "U008", "만료되거나 잘못된 인증 코드입니다."),
-    BUSINESS_NUMBER_INVALID(CONFLICT, "U009", "사업자등록번호가 잘못되었습니다."),
-    MEMBER_IMAGE_NOT_FOUND(NOT_FOUND,"U010","사용자 프로필 이미지를 찾을 수 없습니다"),
-
-    // Company
-    COMPANY_NOT_FOUND(NOT_FOUND,"COM001", "회사를 찾을 수 없습니다."),
-    COMPANY_IMAGE_NOT_FOUND(NOT_FOUND,"COM002","기업 이미지를 찾을 수 없습니다."),
-
-    // JobPost
-    JOBPOST_NOT_FOUND(NOT_FOUND,"J001","채용 공고를 찾을 수 없습니다."),
-    EXPIRED_JOB_POST(FORBIDDEN,"J002","지원 마감된 공고입니다."),
-
-    // Security
-    NEED_AUTHORIZED(UNAUTHORIZED, "S001", "인증이 필요합니다."),
-    ACCESS_DENIED(FORBIDDEN, "S002", "접근 권한이 없습니다."),
-    JWT_EXPIRED(UNAUTHORIZED, "S003", "인증 정보가 만료되었습니다."),
-    JWT_INVALID(UNAUTHORIZED, "S004", "인증 정보가 잘못되었습니다."),
-    JWT_NOT_EXIST(UNAUTHORIZED, "S005", "인증 정보가 존재하지 않습니다."),
-
-    // Resume
-    RESUME_FORBIDDEN(FORBIDDEN,"R001","접근할 수 없는 이력서입니다."),
-    RESUME_NOT_FOUND(NOT_FOUND, "R002", "존재하지 않는 이력서입니다."),
-
-    // Image
-    FILE_SYSTEM_SAVE_FAILED(INTERNAL_SERVER_ERROR, "F001", "파일 시스템에 이미지를 저장할 수 없습니다."),
-    IMAGE_UPLOAD_FAILED(INTERNAL_SERVER_ERROR,"F002","이미지 저장에 실패하였습니다."),
-    IMAGE_DELETE_FAILED(INTERNAL_SERVER_ERROR,"F003","이미지 삭제에 실패하였습니다."),
-    INVALID_IMAGE_NAME(BAD_REQUEST,"F004","잘못된 이미지 이름입니다."),
-    INVALID_IMAGE_TYPE(BAD_REQUEST,"F005","잘못된 이미지 형식입니다."),
-    PRESIGNED_GENERATE_ERROR(INTERNAL_SERVER_ERROR,"F006","PresignedURL 생성 오류"),
-
-
-    //Application
-    DUPLICATED_APPLICATION(FORBIDDEN,"A001", "중복된 지원입니다."),
-
-    // Notification
-    NOTIFICATION_NOT_FOUND(NOT_FOUND,"N001","해당하는 알림을 찾을 수 없습니다.")
-
     ;
 
     private final HttpStatus status;

--- a/src/main/java/avengers/lion/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/avengers/lion/global/exception/GlobalExceptionHandler.java
@@ -59,20 +59,6 @@ public class GlobalExceptionHandler {
                 .body(ResponseUtil.createFailureResponse(ExceptionType.INVALID_ENDPOINT));
     }
 
-    @ExceptionHandler(AccessDeniedException.class)
-    public ResponseEntity<ResponseBody<Void>> handleAccessDeniedException(AccessDeniedException e) {
-        log.error("AccessDeniedException : {}", e);
-        return ResponseEntity
-                .status(ExceptionType.ACCESS_DENIED.getStatus())
-                .body(ResponseUtil.createFailureResponse(ExceptionType.ACCESS_DENIED));
-    }
-
-    @ExceptionHandler(AuthenticationCredentialsNotFoundException.class)
-    public ResponseEntity<ResponseBody<Void>> handleAuthenticationCredentialsNotFoundException(AuthenticationCredentialsNotFoundException e) {
-        return ResponseEntity
-                .status(ExceptionType.NEED_AUTHORIZED.getStatus())
-                .body(ResponseUtil.createFailureResponse(ExceptionType.NEED_AUTHORIZED));
-    }
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ResponseBody<Void>> handleException(Exception e){

--- a/src/main/java/avengers/lion/global/jwt/JwtAccessDeniedHandler.java
+++ b/src/main/java/avengers/lion/global/jwt/JwtAccessDeniedHandler.java
@@ -1,0 +1,34 @@
+package avengers.lion.global.jwt;
+
+import avengers.lion.global.response.FailedResponseBody;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response,
+                       AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+
+        FailedResponseBody failedResponse = new FailedResponseBody("FORBIDDEN", "접근 권한이 없습니다");
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        String jsonResponse = objectMapper.writeValueAsString(failedResponse);
+        response.getWriter().write(jsonResponse);
+    }
+}

--- a/src/main/java/avengers/lion/global/jwt/JwtAuthenticationFailEntryPoint.java
+++ b/src/main/java/avengers/lion/global/jwt/JwtAuthenticationFailEntryPoint.java
@@ -1,0 +1,34 @@
+package avengers.lion.global.jwt;
+
+import avengers.lion.global.response.FailedResponseBody;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFailEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+                         AuthenticationException authException) throws IOException, ServletException {
+        
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+
+        FailedResponseBody failedResponse = new FailedResponseBody("UNAUTHORIZED", "인증이 필요합니다");
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        String jsonResponse = objectMapper.writeValueAsString(failedResponse);
+        response.getWriter().write(jsonResponse);
+    }
+}

--- a/src/main/java/avengers/lion/global/jwt/JwtFilter.java
+++ b/src/main/java/avengers/lion/global/jwt/JwtFilter.java
@@ -1,0 +1,49 @@
+package avengers.lion.global.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtFilter extends OncePerRequestFilter {
+
+    private static final String ACCESS_HEADER = "Authorization";
+
+    private final TokenProvider tokenProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException{
+
+        String accessToken = getTokenFromHeader(request, ACCESS_HEADER);
+
+        if(tokenProvider.validateToken(accessToken) && tokenProvider.validateExpire(accessToken)){
+            SecurityContextHolder.getContext().setAuthentication(tokenProvider.getAuthentication(accessToken));
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    /*
+    Authorization 헤더에서 토큰 추출
+     */
+    public String getTokenFromHeader(HttpServletRequest request, String headerName){
+        String header = request.getHeader(headerName);
+        if(header == null || !header.startsWith("Bearer ")){
+            return null;
+        }
+        return header.substring(7);
+    }
+
+}

--- a/src/main/java/avengers/lion/global/jwt/TokenDto.java
+++ b/src/main/java/avengers/lion/global/jwt/TokenDto.java
@@ -1,0 +1,4 @@
+package avengers.lion.global.jwt;
+
+public record TokenDto(String accessToken, String refreshToken) {
+}

--- a/src/main/java/avengers/lion/global/jwt/TokenProvider.java
+++ b/src/main/java/avengers/lion/global/jwt/TokenProvider.java
@@ -1,0 +1,132 @@
+package avengers.lion.global.jwt;
+
+import avengers.lion.auth.domain.KakaoMemberDetails;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+/*
+토큰 생성, 검증 클래스
+ */
+@Component
+public class TokenProvider {
+
+    private static final String AUTH_KEY = "AUTHORITY";
+    private static final String AUTH_EMAIL = "EMAIL";
+
+    @Value("${jwt.secret-key}")
+    private final String secretKey;
+    @Value("${jwt.access-token-validity-milli-seconds}")
+    private final long accessTokenValidityMilliSeconds;
+    @Value("${jwt.refresh-token-validity-milli-seconds}")
+    private final long refreshTokenValidityMilliSeconds;
+
+    private Key secretkey;
+
+    @PostConstruct
+    public void initKey(){
+        byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+        this.secretkey = Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    /*
+    Access, Refresh token 생성
+     */
+    public TokenDto createToken(String email, String role){
+        long now = (new Date()).getTime();
+
+        Date accessValidity = new Date(now + this.accessTokenValidityMilliSeconds);
+        Date refreshValidity = new Date(now + this.refreshTokenValidityMilliSeconds);
+
+        // 액세스 토큰 생성
+        String accessToken = Jwts.builder()
+                .addClaims(Map.of(AUTH_EMAIL, email))
+                .addClaims(Map.of(AUTH_KEY, role))
+                .signWith(secretkey, SignatureAlgorithm.HS256)
+                .setExpiration(accessValidity)
+                .compact();
+
+        // 리프레시 토큰 생성
+        String refreshToken = Jwts.builder()
+                .addClaims(Map.of(AUTH_EMAIL, email))
+                .addClaims(Map.of(AUTH_KEY, role))
+                .signWith(secretkey, SignatureAlgorithm.HS256)
+                .setExpiration(refreshValidity)
+                .compact();
+
+        return new TokenDto(accessToken, refreshToken);
+    }
+
+    /*
+    토큰이 유효한 지 검사
+     */
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder()
+                    .setSigningKey(secretKey)
+                    .build()
+                    .parseClaimsJws(token);
+            return true;
+        } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
+            return false;
+        } catch (UnsupportedJwtException e) {
+            return false;
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    /*
+    토큰이 만료되었는지 검사
+     */
+    public boolean validateExpire(String token) {
+        try {
+            Jwts.parserBuilder()
+                    .setSigningKey(secretKey)
+                    .build()
+                    .parseClaimsJws(token);
+            return true;
+        } catch (ExpiredJwtException e) {
+            return false;
+        }
+    }
+
+    // token으로부터 Authentication 객체를 만들어 리턴하는 메소드
+    public Authentication getAuthentication(String token) {
+        Claims claims = Jwts.parserBuilder()
+                .setSigningKey(secretKey)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+
+        List<String> authorities = Arrays.asList(claims.get(AUTH_KEY)
+                .toString()
+                .split(","));
+
+        List<? extends GrantedAuthority> simpleGrantedAuthorities = authorities.stream()
+                .map(SimpleGrantedAuthority::new)
+                .collect(Collectors.toList());
+
+        KakaoMemberDetails principal = new KakaoMemberDetails(
+                (String) claims.get(AUTH_EMAIL),
+                simpleGrantedAuthorities, Map.of());
+
+        return new UsernamePasswordAuthenticationToken(principal, token, simpleGrantedAuthorities);
+    }
+}

--- a/src/main/java/avengers/lion/global/jwt/TokenProvider.java
+++ b/src/main/java/avengers/lion/global/jwt/TokenProvider.java
@@ -27,9 +27,9 @@ public class TokenProvider {
 
     @Value("${jwt.secret-key}")
     private String secretKey;
-    @Value("${jwt.access-token-validity-milli-seconds}")
+    @Value("${jwt.access-token-validity-in-seconds}")
     private long accessTokenValidityMilliSeconds;
-    @Value("${jwt.refresh-token-validity-milli-seconds}")
+    @Value("${jwt.refresh-token-validity-in-seconds}")
     private long refreshTokenValidityMilliSeconds;
 
     private Key secretkey;

--- a/src/main/java/avengers/lion/global/jwt/TokenProvider.java
+++ b/src/main/java/avengers/lion/global/jwt/TokenProvider.java
@@ -74,7 +74,7 @@ public class TokenProvider {
     public boolean validateToken(String token) {
         try {
             Jwts.parserBuilder()
-                    .setSigningKey(secretKey)
+                    .setSigningKey(secretkey)
                     .build()
                     .parseClaimsJws(token);
             return true;

--- a/src/main/java/avengers/lion/global/jwt/TokenProvider.java
+++ b/src/main/java/avengers/lion/global/jwt/TokenProvider.java
@@ -5,7 +5,6 @@ import io.jsonwebtoken.*;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
-import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -14,13 +13,9 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.stereotype.Component;
 
 import java.security.Key;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
+import java.util.*;
 
-@RequiredArgsConstructor
+
 /*
 토큰 생성, 검증 클래스
  */
@@ -31,11 +26,11 @@ public class TokenProvider {
     private static final String AUTH_EMAIL = "EMAIL";
 
     @Value("${jwt.secret-key}")
-    private final String secretKey;
+    private String secretKey;
     @Value("${jwt.access-token-validity-milli-seconds}")
-    private final long accessTokenValidityMilliSeconds;
+    private long accessTokenValidityMilliSeconds;
     @Value("${jwt.refresh-token-validity-milli-seconds}")
-    private final long refreshTokenValidityMilliSeconds;
+    private long refreshTokenValidityMilliSeconds;
 
     private Key secretkey;
 
@@ -119,9 +114,8 @@ public class TokenProvider {
                 .toString()
                 .split(","));
 
-        List<? extends GrantedAuthority> simpleGrantedAuthorities = authorities.stream()
-                .map(SimpleGrantedAuthority::new)
-                .collect(Collectors.toList());
+        GrantedAuthority authority = new SimpleGrantedAuthority(claims.get(AUTH_KEY).toString());
+        List<GrantedAuthority> simpleGrantedAuthorities = Collections.singletonList(authority);
 
         KakaoMemberDetails principal = new KakaoMemberDetails(
                 (String) claims.get(AUTH_EMAIL),

--- a/src/main/java/avengers/lion/member/Member.java
+++ b/src/main/java/avengers/lion/member/Member.java
@@ -1,0 +1,42 @@
+package avengers.lion.member;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Member {
+
+    @Id 
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_id")
+    private Long memberId;
+
+    @Column(name = "email", nullable = false, unique = true)
+    private String email;
+
+    @Column(name = "nickname", nullable = false)
+    private String nickname;
+
+    @Column(name = "profile_image_url")
+    private String profileImageUrl;
+
+    @Column(name = "role", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private MemberRole role;
+
+    @Column(name = "point", nullable = false)
+    private int point;
+
+    @Builder
+    public Member(String email, String nickname, MemberRole role, String profileImageUrl) {
+        this.email = email;
+        this.nickname = nickname;
+        this.profileImageUrl = profileImageUrl;
+        this.role = role;
+        this.point = 0;
+    }
+}

--- a/src/main/java/avengers/lion/member/MemberRole.java
+++ b/src/main/java/avengers/lion/member/MemberRole.java
@@ -1,0 +1,14 @@
+package avengers.lion.member;
+
+import lombok.Getter;
+
+@Getter
+public enum MemberRole {
+    ROLE_USER("일반 사용자"), ROLE_ADMIN("관리자");
+
+    private String name;
+
+    MemberRole(String name){
+        this.name=name;
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -37,7 +37,7 @@ redis:
   port: 6379
 
 jwt:
-  secret-key: TestSecretKeyForJUnitTesting
+  secret-key: TestSecretKeyForJUnitTestingThisIsLongEnoughForHS256Algorithm
   access-token-validity-in-seconds: 3600
   refresh-token-validity-in-seconds: 86400
 

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -11,3 +11,51 @@ spring:
   h2:
     console:
       enabled: true
+  security:
+    oauth2:
+      client:
+        registration:
+          kakao:
+            client-id: test-client-id
+            client-secret: test-client-secret
+            client-name: Kakao
+            authorization-grant-type: authorization_code
+            redirect-uri: "http://localhost:8080/login/oauth2/code/kakao"
+            client-authentication-method: client_secret_post
+            scope:
+              - profile_nickname
+              - profile_image
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
+
+redis:
+  host: localhost
+  port: 6379
+
+jwt:
+  secret-key: TestSecretKeyForJUnitTesting
+  access-token-validity-in-seconds: 3600
+  refresh-token-validity-in-seconds: 86400
+
+springdoc:
+  packagesToScan: avengers.lion
+  default-consumes-media-type: application/json;charset=UTF-8
+  default-produces-media-type: application/json;charset=UTF-8
+  swagger-ui:
+    path: /docs
+    disable-swagger-default-url: true
+    operations-sorter: alpha
+    display-request-duration: true
+    tags-sorter: alpha
+  api-docs:
+    groups:
+      enabled: false
+
+swagger:
+  server:
+    url: http://localhost:8080
+    description: Test server


### PR DESCRIPTION

## What is this PR?🔍

카카오 OAuth 2.0 로그인 기능을 구현하여 사용자가 카카오 계정으로 간편하게 로그인할 수 있도록 합니다.

## Changes💻

- 카카오 OAuth 2.0 인증 처리 로직 구현
- JWT 토큰 생성 및 검증 기능 추가
- Spring Security 설정을 통한 인증/인가 구조 구축
- 회원 도메인 및 리포지토리 생성
- CORS 설정 추가로 프론트엔드 연동 준비


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 카카오 OAuth2 소셜 로그인 기능이 추가되었습니다.
  * JWT 기반 인증 및 토큰 발급 기능이 도입되었습니다.
  * 회원 정보(이메일, 닉네임, 프로필 이미지) 저장과 회원 역할(일반 사용자, 관리자) 관리가 가능합니다.
  * JWT 토큰을 활용한 인증 및 권한 부여가 적용되었습니다.
  * CORS 정책 설정으로 프론트엔드(로컬호스트)와의 연동이 개선되었습니다.
  * OAuth2 로그인 성공 시 JWT 토큰이 JSON 형태로 발급 및 반환됩니다.
  * 보안 설정이 강화되어 세션리스(stateless) 방식과 커스텀 필터 및 핸들러가 적용되었습니다.

* **버그 수정**
  * 불필요하거나 중복된 예외 타입이 정리되었습니다.
  * 글로벌 예외 처리에서 일부 보안 관련 예외 핸들러가 제거되어 일관된 예외 처리로 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->