### PR TITLE
feat : Redis 리프레시 토큰 재발급 로직

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,9 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
+	// redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
 
 }
 

--- a/src/main/java/avengers/lion/auth/RefreshTokenController.java
+++ b/src/main/java/avengers/lion/auth/RefreshTokenController.java
@@ -1,5 +1,6 @@
 package avengers.lion.auth;
 
+import avengers.lion.auth.domain.KakaoMemberDetails;
 import avengers.lion.auth.service.RefreshTokenService;
 import avengers.lion.global.response.ResponseBody;
 import avengers.lion.global.response.ResponseUtil;
@@ -22,9 +23,9 @@ public class RefreshTokenController {
 
     @PostMapping
     @PreAuthorize("hasRole('ROLE_USER')")
-    public ResponseEntity<ResponseBody<Void>> refreshToken(@AuthenticationPrincipal Long userId, @RequestHeader("Refresh-Token") String refreshToken,
+    public ResponseEntity<ResponseBody<Void>> refreshToken(@AuthenticationPrincipal KakaoMemberDetails kakaoMemberDetails, @RequestHeader("Refresh-Token") String refreshToken,
                                                            HttpServletResponse response){
-        refreshTokenService.reissueRefreshToken(userId, refreshToken, response);
+        refreshTokenService.reissueRefreshToken(kakaoMemberDetails.getMemberId(), refreshToken, response);
         return ResponseEntity.ok(ResponseUtil.createSuccessResponse());
     }
 }

--- a/src/main/java/avengers/lion/auth/RefreshTokenController.java
+++ b/src/main/java/avengers/lion/auth/RefreshTokenController.java
@@ -1,0 +1,30 @@
+package avengers.lion.auth;
+
+import avengers.lion.auth.service.RefreshTokenService;
+import avengers.lion.global.response.ResponseBody;
+import avengers.lion.global.response.ResponseUtil;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/refreshToken")
+public class RefreshTokenController {
+
+    private final RefreshTokenService refreshTokenService;
+
+    @PostMapping
+    @PreAuthorize("hasRole('ROLE_USER')")
+    public ResponseEntity<ResponseBody<Void>> refreshToken(@AuthenticationPrincipal Long userId, @RequestHeader("Refresh-Token") String refreshToken,
+                                                           HttpServletResponse response){
+        refreshTokenService.reissueRefreshToken(userId, refreshToken, response);
+        return ResponseEntity.ok(ResponseUtil.createSuccessResponse());
+    }
+}

--- a/src/main/java/avengers/lion/auth/domain/KakaoMemberDetails.java
+++ b/src/main/java/avengers/lion/auth/domain/KakaoMemberDetails.java
@@ -1,5 +1,6 @@
 package avengers.lion.auth.domain;
 
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.oauth2.core.user.OAuth2User;
@@ -16,6 +17,8 @@ OAuth2User 인터페이스의 구현체로 작성해야 Authentication 객체 �
 public class KakaoMemberDetails implements OAuth2User {
 
     private final String email;
+    @Getter
+    private final Long memberId;
     private final List<? extends GrantedAuthority> authorities;
     private final Map<String, Object> attributes;
 

--- a/src/main/java/avengers/lion/auth/repository/RefreshTokenRedisImpl.java
+++ b/src/main/java/avengers/lion/auth/repository/RefreshTokenRedisImpl.java
@@ -1,0 +1,37 @@
+package avengers.lion.auth.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class RefreshTokenRedisImpl implements RefreshTokenRepository {
+
+    private final StringRedisTemplate redis;
+
+    /*
+    리프레시 토큰 레디스에 저장
+     */
+    public void saveRefreshToken(Long userId, String refreshToken){
+        String key = "refreshToken:" + userId;
+        redis.opsForValue().set(key, refreshToken, Duration.ofDays(7));
+    }
+
+    /*
+    리프레시 토큰 조회
+     */
+    public Optional<String> findRefreshToken(Long userId){
+        String key = "refreshToken:" + userId;
+        String token = redis.opsForValue().get(key);
+        return Optional.ofNullable(token);
+    }
+
+    public void deleteRefreshToken(Long userId){
+        redis.delete("refreshToken:" + userId);
+    }
+
+}

--- a/src/main/java/avengers/lion/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/avengers/lion/auth/repository/RefreshTokenRepository.java
@@ -1,0 +1,12 @@
+package avengers.lion.auth.repository;
+
+import java.util.Optional;
+
+public interface RefreshTokenRepository {
+
+    void saveRefreshToken(Long userId, String refreshToken);
+
+    Optional<String> findRefreshToken(Long userId);
+
+    void deleteRefreshToken(Long userId);
+}

--- a/src/main/java/avengers/lion/auth/service/KakaoMemberDetailsService.java
+++ b/src/main/java/avengers/lion/auth/service/KakaoMemberDetailsService.java
@@ -7,6 +7,7 @@ import avengers.lion.auth.repository.MemberRepository;
 import avengers.lion.member.Member;
 import avengers.lion.member.MemberRole;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
@@ -22,6 +23,7 @@ import java.util.Collections;
 /*
 OAuth2 사용자 정보 처리
  */
+@Slf4j
 public class KakaoMemberDetailsService extends DefaultOAuth2UserService {
 
     private final MemberRepository memberRepository;
@@ -30,6 +32,7 @@ public class KakaoMemberDetailsService extends DefaultOAuth2UserService {
     @Transactional
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
         OAuth2User oAuth2User = super.loadUser(userRequest);
+        log.info("oAuth2User : {}", oAuth2User);
         // request 에서 사용자 정보가 담긴 객체를 가져옴
         KakaoUserInfo kakaoUserInfo = new KakaoUserInfo(oAuth2User.getAttributes());
 
@@ -43,8 +46,9 @@ public class KakaoMemberDetailsService extends DefaultOAuth2UserService {
                                         .role(MemberRole.ROLE_USER)
                                         .build()
                         ));
+        log.info("member : {}", member);
         SimpleGrantedAuthority authority = new SimpleGrantedAuthority(member.getRole().name());
-        return new KakaoMemberDetails(String.valueOf(member.getEmail()),
+        return new KakaoMemberDetails(kakaoUserInfo.getEmail(),member.getMemberId(),
                 Collections.singletonList(authority),
                 oAuth2User.getAttributes());
     }

--- a/src/main/java/avengers/lion/auth/service/RefreshTokenService.java
+++ b/src/main/java/avengers/lion/auth/service/RefreshTokenService.java
@@ -26,7 +26,7 @@ public class RefreshTokenService {
         if(!refreshToken.equals(redisRefreshToken))
             throw new BusinessException(ExceptionType.INVALID_REFRESH_TOKEN);
         // 레디스에 리프레시 토큰이 존재하면, 액세스 토큰과 리프레시 토큰 재발급
-        TokenDto tokenDto = tokenProvider.createToken(userId.toString(), "ROLE_USER");
+        TokenDto tokenDto = tokenProvider.createToken(userId, "ROLE_USER");
         refreshTokenRepository.deleteRefreshToken(userId);
         refreshTokenRepository.saveRefreshToken(userId, tokenDto.refreshToken());
         response.setHeader("Access-Token", tokenDto.accessToken());

--- a/src/main/java/avengers/lion/auth/service/RefreshTokenService.java
+++ b/src/main/java/avengers/lion/auth/service/RefreshTokenService.java
@@ -16,19 +16,19 @@ public class RefreshTokenService {
     private final RefreshTokenRepository refreshTokenRepository;
     private final TokenProvider tokenProvider;
 
-    public void reissueRefreshToken(Long userId, String refreshToken, HttpServletResponse response){
+    public void reissueRefreshToken(Long memberId, String refreshToken, HttpServletResponse response){
         // 리프레시 토큰이 유효한지 확인
         if(!tokenProvider.validateToken(refreshToken))
             throw new BusinessException(ExceptionType.INVALID_REFRESH_TOKEN);
         // 레디스에 리프레시 토큰이 존재하지 않으면 로그인 실패
-        String redisRefreshToken = refreshTokenRepository.findRefreshToken(userId)
+        String redisRefreshToken = refreshTokenRepository.findRefreshToken(memberId)
                 .orElseThrow(()->new BusinessException(ExceptionType.EXPIRED_REFRESH_TOKEN));
         if(!refreshToken.equals(redisRefreshToken))
             throw new BusinessException(ExceptionType.INVALID_REFRESH_TOKEN);
         // 레디스에 리프레시 토큰이 존재하면, 액세스 토큰과 리프레시 토큰 재발급
-        TokenDto tokenDto = tokenProvider.createToken(userId, "ROLE_USER");
-        refreshTokenRepository.deleteRefreshToken(userId);
-        refreshTokenRepository.saveRefreshToken(userId, tokenDto.refreshToken());
+        TokenDto tokenDto = tokenProvider.createToken(memberId, "ROLE_USER");
+        refreshTokenRepository.deleteRefreshToken(memberId);
+        refreshTokenRepository.saveRefreshToken(memberId, tokenDto.refreshToken());
         response.setHeader("Access-Token", tokenDto.accessToken());
         response.setHeader("Refresh-Token", tokenDto.refreshToken());
     }

--- a/src/main/java/avengers/lion/auth/service/RefreshTokenService.java
+++ b/src/main/java/avengers/lion/auth/service/RefreshTokenService.java
@@ -1,0 +1,35 @@
+package avengers.lion.auth.service;
+
+import avengers.lion.auth.repository.RefreshTokenRepository;
+import avengers.lion.global.exception.BusinessException;
+import avengers.lion.global.exception.ExceptionType;
+import avengers.lion.global.jwt.TokenDto;
+import avengers.lion.global.jwt.TokenProvider;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RefreshTokenService {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final TokenProvider tokenProvider;
+
+    public void reissueRefreshToken(Long userId, String refreshToken, HttpServletResponse response){
+        // 리프레시 토큰이 유효한지 확인
+        if(!tokenProvider.validateToken(refreshToken))
+            throw new BusinessException(ExceptionType.INVALID_REFRESH_TOKEN);
+        // 레디스에 리프레시 토큰이 존재하지 않으면 로그인 실패
+        String redisRefreshToken = refreshTokenRepository.findRefreshToken(userId)
+                .orElseThrow(()->new BusinessException(ExceptionType.EXPIRED_REFRESH_TOKEN));
+        if(!refreshToken.equals(redisRefreshToken))
+            throw new BusinessException(ExceptionType.INVALID_REFRESH_TOKEN);
+        // 레디스에 리프레시 토큰이 존재하면, 액세스 토큰과 리프레시 토큰 재발급
+        TokenDto tokenDto = tokenProvider.createToken(userId.toString(), "ROLE_USER");
+        refreshTokenRepository.deleteRefreshToken(userId);
+        refreshTokenRepository.saveRefreshToken(userId, tokenDto.refreshToken());
+        response.setHeader("Access-Token", tokenDto.accessToken());
+        response.setHeader("Refresh-Token", tokenDto.refreshToken());
+    }
+}

--- a/src/main/java/avengers/lion/global/OAuth2SuccessHandler.java
+++ b/src/main/java/avengers/lion/global/OAuth2SuccessHandler.java
@@ -15,6 +15,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.core.user.OAuth2User;
@@ -31,6 +32,7 @@ import java.io.IOException;
 우리 서비스 전용 JWT를 발급하고, 클라이언트를 accessToken, refreshToken을 담은 URL로 리다이렉트 하는 역할
 SimpleUrl~~ : 스프링 시큐리티의 기본 성공 핸들러
  */
+@Slf4j
 public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
     private final TokenProvider tokenProvider;
@@ -57,8 +59,10 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         response.setCharacterEncoding("UTF-8");
         response.setStatus(HttpServletResponse.SC_OK);
 
-        SuccessResponseBody<TokenDto> successResponse = new SuccessResponseBody<>(tokenDto);
-
+        SuccessResponseBody<Void> successResponse = new SuccessResponseBody<>();
+        response.setHeader("Access-Token",tokenDto.accessToken());
+        response.setHeader("Refresh-Token",tokenDto.refreshToken());
+        log.info("로그인성공");
         try{
             ObjectMapper objectMapper = new ObjectMapper();
             String jsonResponse = objectMapper.writeValueAsString(successResponse);
@@ -66,6 +70,5 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         } catch(IOException e){
             throw new BusinessException(ExceptionType.UNEXPECTED_SERVER_ERROR);
         }
-
     }
 }

--- a/src/main/java/avengers/lion/global/OAuth2SuccessHandler.java
+++ b/src/main/java/avengers/lion/global/OAuth2SuccessHandler.java
@@ -52,7 +52,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
                 .orElseThrow(()->new BusinessException(ExceptionType.MEMBER_NOT_FOUND));
 
         // 사용자 식별 정보를 이용해 토큰 발급
-        TokenDto tokenDto = tokenProvider.createToken(member.getEmail(), member.getRole().name());
+        TokenDto tokenDto = tokenProvider.createToken(member.getMemberId(), member.getRole().name());
 
         // JSON 응답으로 토큰 반환
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);

--- a/src/main/java/avengers/lion/global/config/RedisConfig.java
+++ b/src/main/java/avengers/lion/global/config/RedisConfig.java
@@ -11,9 +11,9 @@ import org.springframework.data.redis.repository.configuration.EnableRedisReposi
 @Configuration
 public class RedisConfig {
 
-    @Value("${spring.redis.host}")
+    @Value("${redis.host}")
     private String redisHost;
-    @Value("${spring.redis.port}")
+    @Value("${redis.port}")
     private int redisPort;
 
     @Bean

--- a/src/main/java/avengers/lion/global/config/RedisConfig.java
+++ b/src/main/java/avengers/lion/global/config/RedisConfig.java
@@ -1,0 +1,23 @@
+package avengers.lion.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+
+@EnableRedisRepositories
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.redis.host}")
+    private String redisHost;
+    @Value("${spring.redis.port}")
+    private int redisPort;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(redisHost, redisPort);
+    }
+}

--- a/src/main/java/avengers/lion/global/config/security/SecurityConfig.java
+++ b/src/main/java/avengers/lion/global/config/security/SecurityConfig.java
@@ -41,7 +41,7 @@ public class SecurityConfig {
                 // URL 접근 권한 설정
                 .authorizeHttpRequests(auth -> auth
                         // 로그인, 콜백, 퍼블릭 API 허용
-                        .requestMatchers("/", "/oauth2/**", "/login", "/error").permitAll()
+                        .requestMatchers("/", "/oauth2/**", "/login/**", "/error").permitAll()
                         .anyRequest().authenticated()
                 )
                 // OAuth2 로그인 설정
@@ -49,7 +49,7 @@ public class SecurityConfig {
                         .authorizationEndpoint(authz -> authz
                                 .baseUri("/oauth2/authorize"))
                         .redirectionEndpoint(redir -> redir
-                                .baseUri(REDIRECT_URL))
+                                .baseUri("/login/oauth2/code/kakao"))
                         .userInfoEndpoint(ui -> ui
                                 .userService(KakaoMemberDetailsService))
                         // 카카오 로그인에 성공하면, 실행

--- a/src/main/java/avengers/lion/global/exception/ExceptionType.java
+++ b/src/main/java/avengers/lion/global/exception/ExceptionType.java
@@ -18,7 +18,11 @@ public enum ExceptionType {
 
     // Member
     MEMBER_NOT_FOUND(NOT_FOUND, "U001", "사용자를 찾을 수 없습니다."),
-    ;
+
+
+    //Auth
+    EXPIRED_REFRESH_TOKEN(UNAUTHORIZED,"A001","리프레시 토큰이 만료되었습니다."),
+    INVALID_REFRESH_TOKEN(UNAUTHORIZED, "A002","리프레시 토큰이 유효하지 않습니다");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/avengers/lion/global/jwt/TokenProvider.java
+++ b/src/main/java/avengers/lion/global/jwt/TokenProvider.java
@@ -122,7 +122,7 @@ public class TokenProvider {
         List<GrantedAuthority> simpleGrantedAuthorities = Collections.singletonList(authority);
 
         KakaoMemberDetails principal = new KakaoMemberDetails(
-                (String) claims.get(AUTH_EMAIL),
+                claims.get(AUTH_MEMBER_ID).toString(),
                 simpleGrantedAuthorities, Map.of());
 
         return new UsernamePasswordAuthenticationToken(principal, token, simpleGrantedAuthorities);

--- a/src/main/java/avengers/lion/global/jwt/TokenProvider.java
+++ b/src/main/java/avengers/lion/global/jwt/TokenProvider.java
@@ -106,25 +106,29 @@ public class TokenProvider {
         }
     }
 
-    // token으로부터 Authentication 객체를 만들어 리턴하는 메소드
+    /*
+    클라이언트가 보낸 JWT 토큰을 스프링 시큐리티가 이해하는 인증 객체로 변환
+     */
     public Authentication getAuthentication(String token) {
+        // 토큰 서명을 검증
         Claims claims = Jwts.parserBuilder()
                 .setSigningKey(secretKey)
                 .build()
                 .parseClaimsJws(token)
                 .getBody();
-
-        List<String> authorities = Arrays.asList(claims.get(AUTH_KEY)
-                .toString()
-                .split(","));
-
+        // 토큰의 권한을 리스트로 변환
         GrantedAuthority authority = new SimpleGrantedAuthority(claims.get(AUTH_KEY).toString());
         List<GrantedAuthority> simpleGrantedAuthorities = Collections.singletonList(authority);
-
+        // 사용자를 나타내는 principal 객체 생성
         KakaoMemberDetails principal = new KakaoMemberDetails(
-                claims.get(AUTH_MEMBER_ID).toString(),
+                null,
+                Long.valueOf(claims.get(AUTH_MEMBER_ID).toString()),
                 simpleGrantedAuthorities, Map.of());
-
+        /*
+        principal : 인증된 사용자 자체
+        credentials : 사용자 인증을 증명하는 비밀값, jwt에서는 토큰
+        authorities : 사용자가 가진 권한 목록
+         */
         return new UsernamePasswordAuthenticationToken(principal, token, simpleGrantedAuthorities);
     }
 }


### PR DESCRIPTION
## What is this PR? 🔍

Spring Security OAuth2 로그인 후, Redis를 이용한 **리프레시 토큰 저장 및 재발급 기능**을 추가했습니다.



## Changes 💻

- `spring-boot-starter-data-redis` 의존성 추가
- `RedisConfig` 설정 클래스 작성
- `RefreshTokenRepository`, `RefreshTokenRedisImpl` 구현 (Redis 연동)
- `RefreshTokenService` 서비스 클래스 구현
- 리프레시 토큰 재발급 API 컨트롤러 (`POST /api/v1/refreshToken`) 작성
- 로그인 시 토큰 응답 방식 개선 및 Redis에 리프레시 토큰 저장 로직 추가
- 예외 타입 추가 (`EXPIRED_REFRESH_TOKEN`, `INVALID_REFRESH_TOKEN`)
- `TokenProvider`에서 `memberId` 기반 토큰 생성으로 개선



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 리프레시 토큰 재발급을 위한 REST API 엔드포인트가 추가되었습니다.
  * 리프레시 토큰을 Redis에 저장 및 관리하는 기능이 도입되었습니다.
  * Redis 연동을 위한 설정이 추가되었습니다.

* **기능 개선**
  * OAuth2 로그인 성공 시 토큰이 응답 헤더로 전달되도록 변경되었습니다.
  * 토큰 생성 시 이메일 대신 회원 ID를 사용하도록 개선되었습니다.
  * 인증 관련 예외(만료/유효하지 않은 리프레시 토큰) 유형이 추가되었습니다.
  * 인증 및 OAuth2 리다이렉트 URL 패턴이 확장되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->