### PR TITLE
feat : 도메인 설정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ out/
 .vscode/
 /src/main/resources/application.properties
 /src/main/resources/application.yml
+/CLAUDE.md

--- a/src/main/java/avengers/lion/member/Member.java
+++ b/src/main/java/avengers/lion/member/Member.java
@@ -1,9 +1,13 @@
 package avengers.lion.member;
 
+import avengers.lion.mission.domain.CompletedMission;
+import avengers.lion.review.domain.Review;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 @Entity
 @Getter
@@ -30,6 +34,12 @@ public class Member {
 
     @Column(name = "point", nullable = false)
     private int point;
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Review> reviews;
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<CompletedMission> completedMissions;
 
     @Builder
     public Member(String email, String nickname, MemberRole role, String profileImageUrl) {

--- a/src/main/java/avengers/lion/member/Member.java
+++ b/src/main/java/avengers/lion/member/Member.java
@@ -1,5 +1,6 @@
 package avengers.lion.member;
 
+import avengers.lion.global.base.BaseEntity;
 import avengers.lion.mission.domain.CompletedMission;
 import avengers.lion.review.domain.Review;
 import jakarta.persistence.*;
@@ -12,7 +13,7 @@ import java.util.List;
 @Entity
 @Getter
 @NoArgsConstructor
-public class Member {
+public class Member extends BaseEntity {
 
     @Id 
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/avengers/lion/mission/domain/BatchStatus.java
+++ b/src/main/java/avengers/lion/mission/domain/BatchStatus.java
@@ -1,0 +1,15 @@
+package avengers.lion.mission.domain;
+
+import lombok.Getter;
+
+@Getter
+public enum BatchStatus {
+
+    ACTIVE("진행 중인 미션"),
+    COMPLETED("지난 미션");
+
+    BatchStatus(String name){
+        this.name=name;
+    }
+    private final String name;
+}

--- a/src/main/java/avengers/lion/mission/domain/CompletedMission.java
+++ b/src/main/java/avengers/lion/mission/domain/CompletedMission.java
@@ -19,7 +19,7 @@ public class CompletedMission {
     @Column(name = "completed_mission_id", nullable = false)
     private Long CompletedMissionId;
 
-    @Column(name = "member_id", nullable = false)
+    @Column(name = "completed_at", nullable = false)
     private LocalDateTime completedAt;
 
     @Column(name = "image_url")

--- a/src/main/java/avengers/lion/mission/domain/CompletedMission.java
+++ b/src/main/java/avengers/lion/mission/domain/CompletedMission.java
@@ -1,0 +1,39 @@
+package avengers.lion.mission.domain;
+
+import avengers.lion.member.Member;
+import avengers.lion.review.domain.Review;
+import jakarta.persistence.*;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/*
+사용자의 미션 수행 결과 저장
+ */
+@Entity
+@NoArgsConstructor
+public class CompletedMission {
+
+    @Id @GeneratedValue
+    @Column(name = "completed_mission_id", nullable = false)
+    private Long CompletedMissionId;
+
+    @Column(name = "member_id", nullable = false)
+    private LocalDateTime completedAt;
+
+    @Column(name = "image_url")
+    private String imageUrl;
+
+    @OneToMany(mappedBy = "completedMission")
+    private List<Review> reviews;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "mission_id", nullable = false)
+    private Mission mission;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+}

--- a/src/main/java/avengers/lion/mission/domain/CompletedMission.java
+++ b/src/main/java/avengers/lion/mission/domain/CompletedMission.java
@@ -35,5 +35,4 @@ public class CompletedMission {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
-
 }

--- a/src/main/java/avengers/lion/mission/domain/Mission.java
+++ b/src/main/java/avengers/lion/mission/domain/Mission.java
@@ -1,0 +1,39 @@
+package avengers.lion.mission.domain;
+
+import avengers.lion.global.base.BaseEntity;
+import avengers.lion.review.domain.Review;
+import jakarta.persistence.*;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/*
+실제 미션 데이터 -> 구글 api + ai로 생성된 미션 정보
+ */
+@Entity
+@NoArgsConstructor
+public class Mission extends BaseEntity {
+
+    @Id @GeneratedValue
+    @Column(name = "mission_id", nullable = false)
+    private Long missionId;
+
+    @Column(name = "place_name", nullable = false)
+    private String placeName;
+
+    @Column(name = "title", nullable = false)
+    private String title;
+
+    @Column(name = "description", nullable = false)
+    private String description;
+
+    @Column(name = "status", nullable = false)
+    private MissionStatus status;
+
+    @ManyToOne
+    @JoinColumn(name = "mission_batch_id", nullable = false)
+    private MissionBatches missionBatches;
+
+    @OneToMany(mappedBy = "mission")
+    private List<Review> reviews;
+}

--- a/src/main/java/avengers/lion/mission/domain/Mission.java
+++ b/src/main/java/avengers/lion/mission/domain/Mission.java
@@ -47,7 +47,4 @@ public class Mission extends BaseEntity {
     @ManyToOne
     @JoinColumn(name = "mission_batch_id", nullable = false)
     private MissionBatches missionBatches;
-
-    @OneToMany(mappedBy = "mission")
-    private List<Review> reviews;
 }

--- a/src/main/java/avengers/lion/mission/domain/Mission.java
+++ b/src/main/java/avengers/lion/mission/domain/Mission.java
@@ -3,8 +3,11 @@ package avengers.lion.mission.domain;
 import avengers.lion.global.base.BaseEntity;
 import avengers.lion.review.domain.Review;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
 import lombok.NoArgsConstructor;
 
+import java.math.BigDecimal;
 import java.util.List;
 
 /*
@@ -29,6 +32,17 @@ public class Mission extends BaseEntity {
 
     @Column(name = "status", nullable = false)
     private MissionStatus status;
+
+    @Column(name = "latitude", precision = 10, scale = 8)
+    @DecimalMin(value = "-90.0")
+    @DecimalMax(value = "90.0")
+    private BigDecimal latitude;
+
+    @Column(name = "longitude", precision = 11, scale = 8)
+    @DecimalMin(value = "-180.0")
+    @DecimalMax(value = "180.0")
+
+    private BigDecimal longitude;
 
     @ManyToOne
     @JoinColumn(name = "mission_batch_id", nullable = false)

--- a/src/main/java/avengers/lion/mission/domain/MissionBatches.java
+++ b/src/main/java/avengers/lion/mission/domain/MissionBatches.java
@@ -29,6 +29,6 @@ public class MissionBatches {
     @Column(name = "batch_status", nullable = false)
     private BatchStatus batchStatus;
 
-    @OneToMany(mappedBy = "missionBatch")
+    @OneToMany(mappedBy = "missionBatches")
     private List<Mission> missions;
 }

--- a/src/main/java/avengers/lion/mission/domain/MissionBatches.java
+++ b/src/main/java/avengers/lion/mission/domain/MissionBatches.java
@@ -1,0 +1,34 @@
+package avengers.lion.mission.domain;
+
+import jakarta.persistence.*;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/*
+2주마다 새로운 미션 세트를 그룹화 -> 미션의 생명주기 관리
+ */
+@Entity
+@NoArgsConstructor
+public class MissionBatches {
+
+    @Id @GeneratedValue
+    @Column(name = "mission_batch_id", nullable = false)
+    private Long missionBatchId;
+
+    @Column(name = "batch_name", nullable = false)
+    private String batchName;
+
+    @Column(name = "batch_start_date", nullable = false)
+    private LocalDateTime batchStartDate;
+
+    @Column(name = "batch_end_date", nullable = false)
+    private LocalDateTime batchEndDate;
+
+    @Column(name = "batch_status", nullable = false)
+    private BatchStatus batchStatus;
+
+    @OneToMany(mappedBy = "missionBatch")
+    private List<Mission> missions;
+}

--- a/src/main/java/avengers/lion/mission/domain/MissionStatus.java
+++ b/src/main/java/avengers/lion/mission/domain/MissionStatus.java
@@ -1,0 +1,16 @@
+package avengers.lion.mission.domain;
+
+import lombok.Getter;
+
+@Getter
+public enum MissionStatus {
+
+    ACTICE("활성화"),
+    INACTIVE("비활성화");
+
+    MissionStatus(String name){
+        this.name=name;
+    }
+
+    private final String name;
+}

--- a/src/main/java/avengers/lion/place/domain/Place.java
+++ b/src/main/java/avengers/lion/place/domain/Place.java
@@ -1,0 +1,35 @@
+package avengers.lion.place.domain;
+
+import jakarta.persistence.*;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/*
+Google Geocoding API 호출용 장소명 보관
+ */
+@Entity
+@NoArgsConstructor
+public class Place {
+
+    @Id @GeneratedValue
+    @Column(name = "place_id")
+    private Long placeId;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Column(name = "category", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private PlaceCategory category;
+
+    @Column(name = "last_search_date")
+    private LocalDateTime lastSearchDate;
+
+    @Column(name = "season")
+    @Enumerated(EnumType.STRING)
+    private Season season;
+
+    @Column(name = "selection_count")
+    private int selectionCount;
+}

--- a/src/main/java/avengers/lion/place/domain/PlaceCategory.java
+++ b/src/main/java/avengers/lion/place/domain/PlaceCategory.java
@@ -1,0 +1,15 @@
+package avengers.lion.place.domain;
+
+import lombok.Getter;
+
+@Getter
+public enum PlaceCategory {
+
+    RESTAURANT("음식점");
+
+    private final String name;
+
+    PlaceCategory(String name){
+        this.name=name;
+    }
+}

--- a/src/main/java/avengers/lion/place/domain/Season.java
+++ b/src/main/java/avengers/lion/place/domain/Season.java
@@ -1,0 +1,17 @@
+package avengers.lion.place.domain;
+
+import lombok.Getter;
+
+@Getter
+public enum Season {
+    SPRING("봄"),
+    SUMMER("여름"),
+    FALL("가을"),
+    WINTER("겨울");
+
+    Season(String name){
+        this.name=name;
+    }
+
+    private final String name;
+}

--- a/src/main/java/avengers/lion/review/domain/Review.java
+++ b/src/main/java/avengers/lion/review/domain/Review.java
@@ -2,6 +2,7 @@ package avengers.lion.review.domain;
 
 import avengers.lion.global.base.BaseEntity;
 import avengers.lion.member.Member;
+import avengers.lion.mission.domain.CompletedMission;
 import avengers.lion.mission.domain.Mission;
 import jakarta.persistence.*;
 import lombok.NoArgsConstructor;
@@ -28,6 +29,6 @@ public class Review extends BaseEntity {
     private Member member;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "mission_id")
-    private Mission mission;
+    @JoinColumn(name = "completed_mission_id")
+    private CompletedMission completedMission;
 }

--- a/src/main/java/avengers/lion/review/domain/Review.java
+++ b/src/main/java/avengers/lion/review/domain/Review.java
@@ -1,0 +1,33 @@
+package avengers.lion.review.domain;
+
+import avengers.lion.global.base.BaseEntity;
+import avengers.lion.member.Member;
+import avengers.lion.mission.domain.Mission;
+import jakarta.persistence.*;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor
+public class Review extends BaseEntity {
+
+    @Id @GeneratedValue
+    @Column(name = "review_id")
+    private Long reviewId;
+
+    @Column(name = "title", nullable = false)
+    private String title;
+
+    @Column(name = "content", nullable = false)
+    private String content;
+
+    @Column(name = "image_url")
+    private String imageUrl;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "mission_id")
+    private Mission mission;
+}


### PR DESCRIPTION
## What is this PR? 🔍
Spring JPA 기반 핵심 도메인 엔티티를 최초 정의하여 저장 계층의 골격을 완성합니다.  


## Changes 💻
### 1. Mission Layer
| 파일 | 설명 |
|------|------|
| `Mission.java` | 좌표(위·경도) 포함 실제 미션 엔티티 |
| `MissionStatus.java` | `ACTIVE / INACTIVE` 열거형 |
| `MissionBatches.java` | 2주 단위 배치 + `BatchStatus` |
| `CompletedMission.java` | 인증 이미지·완료일·회원 FK |

### 2. Place Layer
| 파일 | 설명 |
|------|------|
| `Place.java` | Google API 연동용 POI 메타 |
| `PlaceCategory.java` | 카테고리(enum) |
| `Season.java` | 계절(enum) |

### 3. Member Layer
* `Member`가 `BaseEntity` 상속, **리뷰·완료미션 양방향** 연관관계 추가

### 4. Review Layer
* `Review.java` – `Member`·`CompletedMission` FK, 기본 필드 정의

